### PR TITLE
vectorized StandardParams linear_ramp_from_hamiltonian

### DIFF
--- a/entropica_qaoa/qaoa/parameters.py
+++ b/entropica_qaoa/qaoa/parameters.py
@@ -771,16 +771,16 @@ class StandardWithBiasParams(AbstractParams):
         """
         if time is None:
             time = float(0.7 * n_steps)
-        # create evenly spaced n_steps at the centers of #n_steps intervals
         dt = time / n_steps
-        times = np.linspace(time * (0.5 / n_steps), time
-                            * (1 - 0.5 / n_steps), n_steps)
-
         # fill betas, gammas_singles and gammas_pairs
-        # Todo (optional): replace by np.linspace for tiny performance gains
-        betas = np.array([dt * (1 - t / time) for t in times])
-        gammas_singles = np.array([dt * t / time for t in times])
-        gammas_pairs = np.array([dt * t / time for t in times])
+        #betas = np.array([dt * (1 - t / time) for t in times])
+        betas = np.linspace((dt / time) * (time * (1 - 0.5 / n_steps)),
+                            (dt / time) * (time * 0.5 / n_steps), n_steps)
+        
+        # gammas_singles = np.array([dt * t / time for t in times])
+        # gammas_pairs = np.array([dt * t / time for t in times])
+        gammas_singles = betas[::-1]
+        gammas_pairs = betas[::-1]
 
         # wrap it all nicely in a qaoa_parameters object
         params = cls((hamiltonian, n_steps),

--- a/entropica_qaoa/qaoa/parameters.py
+++ b/entropica_qaoa/qaoa/parameters.py
@@ -934,14 +934,14 @@ class StandardParams(AbstractParams):
             time = float(0.7 * n_steps)
         # create evenly spaced timesteps at the centers of n_steps intervals
         dt = time / n_steps
-        times = np.linspace(time * (0.5 / n_steps), time
-                            * (1 - 0.5 / n_steps), n_steps)
-
         # fill betas, gammas_singles and gammas_pairs
-        # Todo (optional): replace by np.linspace for tiny performance gains
-        betas = np.array([dt * (1 - t / time) for t in times])
-        gammas = np.array([dt * t / time for t in times])
-
+        #betas = np.array([dt * (1 - t / time) for t in times])
+        betas = np.linspace((dt / time) * (time * (1 - 0.5 / n_steps)),
+                            (dt / time) * (time * 0.5 / n_steps), n_steps)
+        #gammas = np.array([dt * t / time for t in times])
+        #gammas = np.linspace((dt / time) * (time * 0.5 / n_steps),
+        #                    (dt / time) * (time * (1 - 0.5 / n_steps)), n_steps)
+        gammas = betas[::-1]
         # wrap it all nicely in a qaoa_parameters object
         params = cls((hamiltonian, n_steps),
                      (betas, gammas))


### PR DESCRIPTION
Replaced the for loops in calculation of betas and gammas with a linspace version, resulting in roughly 10x faster execution of StandardParams linear_ramp_from_hamiltonian method as used in example notebook #6. 

Runtime before optimization: 1.22 ms ± 10.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

Runtime after optimization: 85.9 µs ± 905 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)