### PR TITLE
Minor Fix for NetworkX 2.4+

### DIFF
--- a/entropica_qaoa/utilities.py
+++ b/entropica_qaoa/utilities.py
@@ -296,7 +296,7 @@ def random_k_regular_graph(degree: int,
 
     if biases:
         for node in G.nodes():
-            G.node[node]['weight'] = np.random.rand()
+            G.nodes[node]['weight'] = np.random.rand()
 
     return G
 


### PR DESCRIPTION
Changed `G.node` to `G.nodes`, otherwise it raises AttributeError.